### PR TITLE
events and new keys (activityKey and bootyBase)

### DIFF
--- a/contracts/SpankBank.sol
+++ b/contracts/SpankBank.sol
@@ -5,263 +5,374 @@ import {MintableToken} from "./MintableToken.sol";
 
 contract SpankBank {
 
-  /***********************************
-  VARIABLES SET AT CONTRACT DEPLOYMENT
-  ************************************/
-  // GLOBAL CONSTANT VARIABLES
-  uint256 public periodLength; // time length of each period in seconds
-  uint256 public maxPeriods;
+    event StakeEvent(
+        address indexed staker,
+        uint indexed startPeriod,
+        uint indexed endPeriod
+    );
+    
+    event SendFeesEvent (
+        address indexed sender,
+        uint indexed bootyAmount,
+        uint indexed currentBootyFees
+    );
 
-  // ERC-20 BASED TOKEN WITH SOME ADDED PROPERTIES FOR HUMAN READABILITY
-  // https://github.com/ConsenSys/Tokens/blob/master/contracts/HumanStandardToken.sol
-  HumanStandardToken public spankToken;
-  MintableToken public bootyToken;
+    event MintBootyEvent (
+        uint indexed targetBootySupply,
+        uint indexed totalBootySupply,
+        uint indexed currentPeriod
+    );
 
-  // LOOKUP TABLE FOR SPANKPOINTS BY PERIOD
-  // 1 -> 45%
-  // 2 -> 50%
-  // ...
-  // 12 -> 100%
-  mapping(uint256 => uint256) pointsTable;
+    event CheckInEvent (
+        address indexed staker,
+        uint indexed updatedEndingPeriod,
+        uint indexed currentPeriod
+    );
 
-  /*************************************
-  INTERAL ACCOUNTING
-  **************************************/
-  uint256 public currentPeriod = 0;
+    event ClaimBootyEvent (
+        address indexed staker,
+        uint indexed period,
+        uint indexed bootyOwed,
+        uint stakerSpankPoints
+    );
 
-  struct Staker {
-    uint256 spankStaked; // the amount of spank staked
-    uint256 startingPeriod; // the period this staker started staking
-    uint256 endingPeriod; // the period after which this stake expires
-    mapping(uint256 => uint256) spankPoints; // the spankPoints per period
-    mapping(uint256 => bool) didClaimBooty; // true if staker claimed BOOTY for that period
-  }
+    event WithdrawStakeEvent (
+        address indexed staker,
+        uint indexed totalSpankStaked,
+        uint indexed currentPeriod
+        
+    );
 
-  mapping(address => Staker) public stakers;
+    event SplitStakeEvent (
+        address indexed staker,
+        address indexed newAddress,
+        uint indexed spankAmount,
+        uint currentPeriod,
+        uint startingPeriod,
+        uint endingPeriod
+    );
 
-  struct Period {
-    uint256 bootyFees; // the amount of BOOTY collected in fees
-    uint256 totalSpankPoints; // the total spankPoints of all stakers
-    uint256 bootyMinted; // the amount of BOOTY minted
-    bool mintingComplete; // true if BOOTY has already been minted for this period
-    uint256 startTime; // the starting unix timestamp in seconds
-    uint256 endTime; // the ending unix timestamp in seconds
-  }
+    event VoteToUnwindEvent (
+        address indexed staker,
+        uint indexed spankStaked,
+        bool indexed unwind,
+        uint currentPeriod,
+        uint totalSpankStaked
+    );
 
-  mapping(uint256 => Period) public periods;
+    /***********************************
+    VARIABLES SET AT CONTRACT DEPLOYMENT
+    ************************************/
+    // GLOBAL CONSTANT VARIABLES
+    uint256 public periodLength; // time length of each period in seconds
+    uint256 public maxPeriods;
+    uint256 public totalSpankStaked;
+    uint256 public unwindVotes;
+    uint256 public unwindPeriod;
+    bool public unwind;
 
-  constructor (
-    uint256 _periodLength,
-    uint256 _maxPeriods,
-    address spankAddress,
-    uint256 initialBootySupply
-  )  public {
-    periodLength = _periodLength;
-    maxPeriods = _maxPeriods;
-    spankToken = HumanStandardToken(spankAddress);
-    bootyToken = new MintableToken();
-    bootyToken.mint(this, initialBootySupply);
+    // ERC-20 BASED TOKEN WITH SOME ADDED PROPERTIES FOR HUMAN READABILITY
+    // https://github.com/ConsenSys/Tokens/blob/master/contracts/HumanStandardToken.sol
+    HumanStandardToken public spankToken;
+    MintableToken public bootyToken;
 
-    uint256 startTime = now;
+    // LOOKUP TABLE FOR SPANKPOINTS BY PERIOD
+    // 1 -> 45%
+    // 2 -> 50%
+    // ...
+    // 12 -> 100%
+    mapping(uint256 => uint256) pointsTable;
 
-    periods[currentPeriod].startTime = startTime;
-    periods[currentPeriod].endTime = SafeMath.add(startTime, periodLength);
+    /*************************************
+    INTERAL ACCOUNTING
+    **************************************/
+    uint256 public currentPeriod = 0;
 
-    bootyToken.transfer(msg.sender, initialBootySupply);
-
-    // initialize points table
-    pointsTable[1] = 45;
-    pointsTable[2] = 50;
-    pointsTable[3] = 55;
-    pointsTable[4] = 60;
-    pointsTable[5] = 65;
-    pointsTable[6] = 70;
-    pointsTable[7] = 75;
-    pointsTable[8] = 80;
-    pointsTable[9] = 85;
-    pointsTable[10] = 90;
-    pointsTable[11] = 95;
-    pointsTable[12] = 100;
-  }
-
-  // Used to create a new staking position - verifies that the caller is not staking
-  function stake(uint256 spankAmount, uint256 stakePeriods) public {
-    updatePeriod();
-
-    require(stakePeriods > 0 && stakePeriods <= maxPeriods); // stake 1-12 (max) periods
-    require(spankAmount > 0); // stake must be greater than 0
-
-    // the msg.sender must not have an active staking position
-    // TODO checking that endingPeriod == 0 should cover all periods
-    require(stakers[msg.sender].startingPeriod == 0 && stakers[msg.sender].endingPeriod == 0);
-
-    // transfer SPANK to this contract - assumes sender has already "allowed" the spankAmount
-    require(spankToken.transferFrom(msg.sender, this, spankAmount));
-
-    // The spankAmount of spankPoints the user will have during the next staking period
-    // TODO the division is unnecessary - we're only dividing by the total
-    uint256 nextSpankPoints = SafeMath.div( SafeMath.mul(spankAmount, pointsTable[stakePeriods]), 100 );
-
-    stakers[msg.sender] = Staker(spankAmount, currentPeriod + 1, currentPeriod + stakePeriods);
-
-    stakers[msg.sender].spankPoints[currentPeriod + 1] = nextSpankPoints;
-
-    uint256 nextTotalSpankPoints = periods[currentPeriod + 1].totalSpankPoints;
-    nextTotalSpankPoints = SafeMath.add(nextTotalSpankPoints, nextSpankPoints);
-    periods[currentPeriod + 1].totalSpankPoints = nextTotalSpankPoints;
-  }
-
-  function getSpankPoints(address stakerAddress, uint256 period) public view returns (uint256)  {
-    return stakers[stakerAddress].spankPoints[period];
-  }
-
-  function getDidClaimBooty(address stakerAddress, uint256 period) public view returns (bool)  {
-    return stakers[stakerAddress].didClaimBooty[period];
-  }
-
-  // user will be able to add more SPANK to their stake and / or extend it
-  // function updateStake(uint256 amount, uint256 periods) {}
-
-  // 1. Anyone calls the mint function, which generates all the new booty for that period
-  //  - what if no one calls mint? the booty supply will be lower for the next round
-  //  - more booty will be created later to compensate (not really a bid deal)
-  // 2. Stakers can withdraw their minted BOOTY
-
-  // Do the fees get calculated for the current period or the next one? Current
-  // Does the minting depends on current stake or next?
-  // If I start staking at 10.5, my stake will only matter for 11, and the BOOTY generated after 11 will be based on the fees paid during 11, and can only be collected after 11 is done
-
-  function sendFees(uint256 bootyAmount) public {
-    updatePeriod();
-
-    require(bootyAmount > 0); // fees must be greater than 0
-    require(bootyToken.transferFrom(msg.sender, this, bootyAmount));
-
-    bootyToken.burn(bootyAmount);
-
-    uint256 currentBootyFees = periods[currentPeriod].bootyFees;
-    currentBootyFees = SafeMath.add(bootyAmount, currentBootyFees);
-    periods[currentPeriod].bootyFees = currentBootyFees;
-  }
-
-  function mintBooty() public {
-    updatePeriod();
-
-    Period storage period = periods[currentPeriod - 1];
-    require(!period.mintingComplete); // cant mint BOOTY twice
-
-    period.mintingComplete = true;
-
-    uint256 targetBootySupply = SafeMath.mul(period.bootyFees, 20);
-    uint256 totalBootySupply = bootyToken.totalSupply();
-
-    if (targetBootySupply > totalBootySupply) {
-      uint256 bootyMinted = targetBootySupply - totalBootySupply;
-      bootyToken.mint(this, bootyMinted);
-      period.bootyMinted = bootyMinted;
-    }
-  }
-
-  // This will check the current time and update the current period accordingly
-  // - called from all write functions to ensure the period is always up to date before any writes
-  // - can also be called externally, but there isn't a good reason for why you would want to
-  // - the while loop protects against the edge case where we miss a period
-
-  function updatePeriod() public {
-    while (now >= periods[currentPeriod].endTime) {
-      Period memory prevPeriod = periods[currentPeriod];
-      currentPeriod += 1;
-      periods[currentPeriod].startTime = prevPeriod.endTime;
-      periods[currentPeriod].endTime = SafeMath.add(prevPeriod.endTime, periodLength);
-    }
-  }
-
-  // In order to receive Booty, each staker will have to check-in every period.
-  // This check-in will compute the spankPoints locally and globally for each staker.
-  function checkIn(uint256 updatedEndingPeriod)  public {
-    updatePeriod();
-
-    Staker storage staker = stakers[msg.sender];
-
-    require(currentPeriod < staker.endingPeriod);
-
-    if (updatedEndingPeriod > 0) {
-      // TODO I'm not sure we can rely on the staker.endingPeriod to be greater than the
-      // currentPeriod - what if the staker expires but never withdraws their stake?
-      require(updatedEndingPeriod > currentPeriod);
-      require(updatedEndingPeriod > staker.endingPeriod);
-      require(updatedEndingPeriod <= currentPeriod + maxPeriods);
-
-      staker.endingPeriod = updatedEndingPeriod;
+    struct Staker {
+        uint256 spankStaked; // the amount of spank staked
+        uint256 startingPeriod; // the period this staker started staking
+        uint256 endingPeriod; // the period after which this stake expires
+        mapping(uint256 => uint256) spankPoints; // the spankPoints per period
+        mapping(uint256 => bool) didClaimBooty; // true if staker claimed BOOTY for that period
+        mapping(uint256 => bool) votedToUnwind; // true if voter voted 
     }
 
-    uint256 stakePeriods = staker.endingPeriod - currentPeriod;
+    mapping(address => Staker) public stakers;
 
-    // TODO combine this and the code from stake into their own function to reduce dup
-
-    // The spankAmount of spankPoints the user will have during the next staking period
-    uint256 nextSpankPoints = SafeMath.div(SafeMath.mul(staker.spankStaked, pointsTable[stakePeriods]), 100);
-
-    staker.spankPoints[currentPeriod + 1] = nextSpankPoints;
-
-    uint256 nextTotalSpankPoints = periods[currentPeriod + 1].totalSpankPoints;
-    nextTotalSpankPoints = SafeMath.add(nextTotalSpankPoints, nextSpankPoints);
-    periods[currentPeriod + 1].totalSpankPoints = nextTotalSpankPoints;
-  }
-
-  function claimBooty(uint256 _period) public {
-    updatePeriod();
-
-    require(_period < currentPeriod); // can only claim booty for previous periods
-
-    Staker storage staker = stakers[msg.sender];
-
-    require(!staker.didClaimBooty[_period]); // can only claim booty once
-
-    staker.didClaimBooty[_period] = true;
-
-    Period memory period = periods[_period];
-    uint256 bootyMinted = period.bootyMinted;
-    uint256 totalSpankPoints = period.totalSpankPoints;
-
-    if (totalSpankPoints > 0) {
-      uint256 stakerSpankPoints = staker.spankPoints[_period];
-      uint256 bootyOwed = SafeMath.div(SafeMath.mul(stakerSpankPoints, bootyMinted), totalSpankPoints);
-
-      require(bootyToken.transfer(msg.sender, bootyOwed));
+    struct Period {
+        uint256 bootyFees; // the amount of BOOTY collected in fees
+        uint256 totalSpankPoints; // the total spankPoints of all stakers
+        uint256 bootyMinted; // the amount of BOOTY minted
+        bool mintingComplete; // true if BOOTY has already been minted for this period
+        uint256 startTime; // the starting unix timestamp in seconds
+        uint256 endTime; // the ending unix timestamp in seconds
     }
-  }
 
-  function withdrawStake() public {
-    updatePeriod();
+    mapping(uint256 => Period) public periods;
 
-    Staker storage staker = stakers[msg.sender];
+    modifier active() {
+      require(unwind == false);
+      _;
+    }
 
-    require(currentPeriod > staker.endingPeriod);
+    constructor (
+        uint256 _periodLength,
+        uint256 _maxPeriods,
+        address spankAddress,
+        uint256 initialBootySupply
+    )   public {
+        periodLength = _periodLength;
+        maxPeriods = _maxPeriods;
+        spankToken = HumanStandardToken(spankAddress);
+        bootyToken = new MintableToken();
+        bootyToken.mint(this, initialBootySupply);
 
-    spankToken.transfer(msg.sender, staker.spankStaked);
+        uint256 startTime = now;
 
-    staker.spankStaked = 0;
-  }
+        periods[currentPeriod].startTime = startTime;
+        periods[currentPeriod].endTime = SafeMath.add(startTime, periodLength);
 
-  function splitStake(address newAddress, uint256 spankAmount) public {
-    updatePeriod();
+        bootyToken.transfer(msg.sender, initialBootySupply);
 
-    require(newAddress != address(0));
-    require(spankAmount > 0);
+        // initialize points table
+        pointsTable[0] = 0;
+        pointsTable[1] = 45;
+        pointsTable[2] = 50;
+        pointsTable[3] = 55;
+        pointsTable[4] = 60;
+        pointsTable[5] = 65;
+        pointsTable[6] = 70;
+        pointsTable[7] = 75;
+        pointsTable[8] = 80;
+        pointsTable[9] = 85;
+        pointsTable[10] = 90;
+        pointsTable[11] = 95;
+        pointsTable[12] = 100;
+    }
 
-    Staker storage staker = stakers[msg.sender];
-    require(currentPeriod < staker.endingPeriod);
-    require(spankAmount <= staker.spankStaked);
-    staker.spankStaked = SafeMath.sub(staker.spankStaked, spankAmount);
+    // Used to create a new staking position - verifies that the caller is not staking
+    function stake(uint256 spankAmount, uint256 stakePeriods) active public {
+        updatePeriod();
 
-    stakers[newAddress] = Staker(spankAmount, staker.startingPeriod, staker.endingPeriod);
-  }
+        require(stakePeriods > 0 && stakePeriods <= maxPeriods, "stake:: stake must be between 0 and maxPeriods"); // stake 1-12 (max) periods
+        require(spankAmount > 0, "stake::spankAmount must be greater than 0"); // stake must be greater than 0
 
-  // TODO as-is, the contract doesnt allow for dynamic stake allocation - you can only extend
-  // the entire stake, or withdraw the entire stake. Even if you could withdraw partial stake,
-  // you would still be making the decision to extend the entire stake, or not.
-  // - allow staker to split stake (or move some fraction under a new address)
-  // - accept that you have to extend the entire stake, and plan ahead accordingly
-  //   - split the stake up into several portions, and decide to extend / not each portion
+        // the msg.sender must not have an active staking position
+        // TODO checking that endingPeriod == 0 should cover all periods
+        require(stakers[msg.sender].startingPeriod == 0 && stakers[msg.sender].endingPeriod == 0, "stake::startingPeriod and endingPeriod must be 0");
+
+        // transfer SPANK to this contract - assumes sender has already "allowed" the spankAmount
+        require(spankToken.transferFrom(msg.sender, this, spankAmount),"stake::spankToken transfer failure");
+
+        // The spankAmount of spankPoints the user will have during the next staking period
+        // TODO the division is unnecessary - we're only dividing by the total
+        uint256 nextSpankPoints = SafeMath.div( SafeMath.mul(spankAmount, pointsTable[stakePeriods]), 100 );
+
+        stakers[msg.sender] = Staker(spankAmount, currentPeriod + 1, currentPeriod + stakePeriods);
+
+        stakers[msg.sender].spankPoints[currentPeriod + 1] = nextSpankPoints;
+
+        uint256 nextTotalSpankPoints = periods[currentPeriod + 1].totalSpankPoints;
+        nextTotalSpankPoints = SafeMath.add(nextTotalSpankPoints, nextSpankPoints);
+        periods[currentPeriod + 1].totalSpankPoints = nextTotalSpankPoints;
+
+        totalSpankStaked = SafeMath.add(totalSpankStaked, spankAmount);
+
+        emit StakeEvent(msg.sender, currentPeriod + 1, currentPeriod + stakePeriods);
+    }
+
+    function getSpankPoints(address stakerAddress, uint256 period) public view returns (uint256)  {
+        return stakers[stakerAddress].spankPoints[period];
+    }
+
+    function getDidClaimBooty(address stakerAddress, uint256 period) public view returns (bool)  {
+        return stakers[stakerAddress].didClaimBooty[period];
+    }
+
+    // user will be able to add more SPANK to their stake and / or extend it
+    // function updateStake(uint256 amount, uint256 periods) {}
+
+    // 1. Anyone calls the mint function, which generates all the new booty for that period
+    //  - what if no one calls mint? the booty supply will be lower for the next round
+    //  - more booty will be created later to compensate (not really a bid deal)
+    // 2. Stakers can withdraw their minted BOOTY
+
+    // Do the fees get calculated for the current period or the next one? Current
+    // Does the minting depends on current stake or next?
+    // If I start staking at 10.5, my stake will only matter for 11, and the BOOTY generated after 11 will be based on the fees paid during 11, and can only be collected after 11 is done
+
+    function sendFees(uint256 bootyAmount) public {
+        updatePeriod();
+
+        require(bootyAmount > 0, "sendFees::fees must be greater than 0"); // fees must be greater than 0
+        require(bootyToken.transferFrom(msg.sender, this, bootyAmount), "sendFees::bootyToken transfer failed");
+
+        bootyToken.burn(bootyAmount);
+
+        uint256 currentBootyFees = periods[currentPeriod].bootyFees;
+        currentBootyFees = SafeMath.add(bootyAmount, currentBootyFees);
+        periods[currentPeriod].bootyFees = currentBootyFees;
+
+        emit SendFeesEvent(msg.sender, bootyAmount, currentBootyFees);
+    }
+
+    function mintBooty() active public {
+        updatePeriod();
+
+        Period storage period = periods[currentPeriod - 1];
+        require(!period.mintingComplete, "mintBooty::mintingComplete must be false"); // cant mint BOOTY twice
+
+        period.mintingComplete = true;
+
+        uint256 targetBootySupply = SafeMath.mul(period.bootyFees, 20);
+        uint256 totalBootySupply = bootyToken.totalSupply();
+
+        if (targetBootySupply > totalBootySupply) {
+            uint256 bootyMinted = targetBootySupply - totalBootySupply;
+            bootyToken.mint(this, bootyMinted);
+            period.bootyMinted = bootyMinted;
+        }
+
+        emit MintBootyEvent(targetBootySupply, totalBootySupply, currentPeriod);
+    }
+
+    // This will check the current time and update the current period accordingly
+    // - called from all write functions to ensure the period is always up to date before any writes
+    // - can also be called externally, but there isn't a good reason for why you would want to
+    // - the while loop protects against the edge case where we miss a period
+
+    function updatePeriod() public {
+        while (now >= periods[currentPeriod].endTime) {
+            Period memory prevPeriod = periods[currentPeriod];
+            currentPeriod += 1;
+            periods[currentPeriod].startTime = prevPeriod.endTime;
+            periods[currentPeriod].endTime = SafeMath.add(prevPeriod.endTime, periodLength);
+        }
+    }
+
+    // In order to receive Booty, each staker will have to check-in every period.
+    // This check-in will compute the spankPoints locally and globally for each staker.
+    function checkIn(uint256 updatedEndingPeriod) active public {
+        updatePeriod();
+
+        Staker storage staker = stakers[msg.sender];
+
+        require(currentPeriod < staker.endingPeriod);
+
+        if (updatedEndingPeriod > 0) {
+            // TODO I'm not sure we can rely on the staker.endingPeriod to be greater than the
+            // currentPeriod - what if the staker expires but never withdraws their stake?
+            require(updatedEndingPeriod > currentPeriod, "checkIn::updatedEndingPeriod must be greater than currentPeriod");
+            require(updatedEndingPeriod > staker.endingPeriod, "checkIn::updatedEndingPeriod must be greater than staker.endingPeriod");
+            require(updatedEndingPeriod <= currentPeriod + maxPeriods, "updatedEndingPeriod must be less than or equal to currentPeriod + maxPeriods");
+
+            staker.endingPeriod = updatedEndingPeriod;
+      }
+
+        uint256 stakePeriods = staker.endingPeriod - currentPeriod;
+
+        // TODO combine this and the code from stake into their own function to reduce dup
+
+        // The spankAmount of spankPoints the user will have during the next staking period
+        uint256 nextSpankPoints = SafeMath.div(SafeMath.mul(staker.spankStaked, pointsTable[stakePeriods]), 100);
+
+        staker.spankPoints[currentPeriod + 1] = nextSpankPoints;
+
+        uint256 nextTotalSpankPoints = periods[currentPeriod + 1].totalSpankPoints;
+        nextTotalSpankPoints = SafeMath.add(nextTotalSpankPoints, nextSpankPoints);
+        periods[currentPeriod + 1].totalSpankPoints = nextTotalSpankPoints;
+
+        emit CheckInEvent(msg.sender, updatedEndingPeriod, currentPeriod);
+    }
+
+    function claimBooty(uint256 _period) public {
+        updatePeriod();
+
+        require(_period < currentPeriod, "claimBooty::_period must be less than currentPeriod"); // can only claim booty for previous periods
+
+        Staker storage staker = stakers[msg.sender];
+
+        require(!staker.didClaimBooty[_period], "claimBooty::didClaimBooty for period must be false"); // can only claim booty once
+
+        staker.didClaimBooty[_period] = true;
+
+        Period memory period = periods[_period];
+        uint256 bootyMinted = period.bootyMinted;
+        uint256 totalSpankPoints = period.totalSpankPoints;
+
+        if (totalSpankPoints > 0) {
+            uint256 stakerSpankPoints = staker.spankPoints[_period];
+            uint256 bootyOwed = SafeMath.div(SafeMath.mul(stakerSpankPoints, bootyMinted), totalSpankPoints);
+
+          require(bootyToken.transfer(msg.sender, bootyOwed), "claimBooty::bootyToken transfer failure");
+
+          emit ClaimBootyEvent(msg.sender, _period, bootyOwed, stakerSpankPoints);
+        }
+    }
+
+    function withdrawStake() public {
+        updatePeriod();
+
+        Staker storage staker = stakers[msg.sender];
+
+        require(currentPeriod > staker.endingPeriod, "withdrawStake::currentPeriod must be greater than staker.endingPeriod");
+
+        spankToken.transfer(msg.sender, staker.spankStaked);
+
+        totalSpankStaked = SafeMath.sub(totalSpankStaked, staker.spankStaked);
+        staker.spankStaked = 0;
+
+        emit WithdrawStakeEvent(msg.sender, totalSpankStaked, currentPeriod);
+    }
+
+    function splitStake(address newAddress, uint256 spankAmount) public {
+        updatePeriod();
+
+        require(newAddress != address(0), "splitStake::newAddress must be a non-zero address");
+        require(spankAmount > 0, "splitStake::spankAmount must be greater than 0");
+
+        Staker storage staker = stakers[msg.sender];
+        require(currentPeriod < staker.endingPeriod, "currentPeriod must be less than staker.endingPeriod");
+        require(spankAmount <= staker.spankStaked, "spankAmount must be less than or equal to staker.spankStaked");
+        staker.spankStaked = SafeMath.sub(staker.spankStaked, spankAmount);
+
+        stakers[newAddress] = Staker(spankAmount, staker.startingPeriod, staker.endingPeriod);
+
+        emit SplitStakeEvent(msg.sender, newAddress, spankAmount, currentPeriod, staker.startingPeriod, staker.endingPeriod);
+    }
+
+    function voteToUnwind() public {
+        updatePeriod();
+
+        require(unwind == false);
+        
+        Staker storage staker = stakers[msg.sender];
+        require(staker.spankStaked > 0);
+        require(staker.endingPeriod >= currentPeriod);
+        
+
+        if (unwindPeriod != currentPeriod) {
+            unwindPeriod = currentPeriod;
+            unwindVotes = 0;
+            staker.votedToUnwind[currentPeriod] = false;
+        }
+        
+        require (staker.votedToUnwind[currentPeriod] == false);
+        staker.votedToUnwind[currentPeriod] = true;
+        unwindVotes = SafeMath.add(unwindVotes, staker.spankStaked);
+
+        uint256 unwindTrigger = SafeMath.div(totalSpankStaked, 2);
+        if (unwindVotes > unwindTrigger) {
+            unwind = true;
+        }
+
+        emit VoteToUnwindEvent(msg.sender, staker.spankStaked, unwind, currentPeriod, totalSpankStaked);
+    }
+
+    // TODO as-is, the contract doesnt allow for dynamic stake allocation - you can only extend
+    // the entire stake, or withdraw the entire stake. Even if you could withdraw partial stake,
+    // you would still be making the decision to extend the entire stake, or not.
+    // - allow staker to split stake (or move some fraction under a new address)
+    // - accept that you have to extend the entire stake, and plan ahead accordingly
+    //   - split the stake up into several portions, and decide to extend / not each portion
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "solc": "=0.4.15",
-    "truffle": "^4.1.11"
+    "truffle": "^4.1.11",
+    "truffle-hdwallet-provider": "0.0.5"
   }
 }

--- a/truffle.js
+++ b/truffle.js
@@ -1,3 +1,7 @@
+const HDWalletProvider = require("truffle-hdwallet-provider");
+
+const mnemonic = 'denial replace woman enroll deer client live clog fan rib assume maple'
+
 module.exports = {
   networks: {
     development: {
@@ -5,5 +9,11 @@ module.exports = {
       port: 8545,
       network_id: "*" // match any network
     },
+    rinkeby: {
+      provider: function() {
+        return new HDWalletProvider(mnemonic, "https://rinkeby.infura.io/M2xeaVefzxkLhvrTLq43")
+      },
+      network_id: 4
+    }  
   }
 };


### PR DESCRIPTION
1. events - first pass, will most likely need to add more payload data depending on explorer UI
2. new keys - there are now 3 separate keys that can be used, divided in to roles : 
- staking key : used for initial stake, otherwise meant to be kept in cold storage
- activity key : used for monthly staking management (delegate key with no access to funds)
- booty key : address where booty goes

The thinking is that high value stakers will appreciate this separation while low value stakers will keep all keys the same (thinking all keys the same will be default UI as well).