### PR TITLE
Name refactor and optimization

### DIFF
--- a/contracts/MintAndBurnToken.sol
+++ b/contracts/MintAndBurnToken.sol
@@ -10,7 +10,7 @@ import "./OZ_Ownable.sol";
  * @dev Issue: * https://github.com/OpenZeppelin/zeppelin-solidity/issues/120
  * Based on code by TokenMarketNet: https://github.com/TokenMarketNet/ico/blob/master/contracts/MintableToken.sol
  */
-contract MintableToken is StandardToken, Ownable {
+contract MintAndBurnToken is StandardToken, Ownable {
   event Mint(address indexed to, uint256 amount);
   event MintFinished();
 


### PR DESCRIPTION
Fixes #15 , Fixes #16 , adds multi-signature wallet support for staking (receiveApproval), update sendBootyAddress to bootyBase, update uint to uint256, update active modifier to SpankBankIsOpen, update _staking to doStake, and stake to stakeFromPrivateKey. Use staking key for `voteToClose`. Remove closingPeriod and closingVotes. Rename MintableToken to MintAndBurnToken.

Add closingVotes and totalStakedSpank to Period struct (only count active stakes when tallying stake votes)